### PR TITLE
Fix all-day events showing one day early west of UTC

### DIFF
--- a/calendar-tasks-card.js
+++ b/calendar-tasks-card.js
@@ -1459,7 +1459,7 @@ class CalendarTasksCard extends HTMLElement {
         if (Array.isArray(resp)) resp.forEach(ev => results.push({ ...ev, _source: id }));
       } catch (e) { console.warn(`[ctc] Errore calendario ${id}:`, e); }
     }
-    results.sort((a, b) => new Date(a.start.dateTime || a.start.date) - new Date(b.start.dateTime || b.start.date));
+    results.sort((a, b) => parseDueDate(a.start.dateTime || a.start.date) - parseDueDate(b.start.dateTime || b.start.date));
     return results;
   }
 
@@ -1799,7 +1799,8 @@ class CalendarTasksCard extends HTMLElement {
       date.setDate(date.getDate() + i);
       date.setHours(0, 0, 0, 0);
       const dk = dayKey(date);
-      const dayEvents = this._events.filter(ev => dayKey(new Date(ev.start.dateTime || ev.start.date)) === dk);
+      // parseDueDate: new Date("YYYY-MM-DD") è mezzanotte UTC, non locale.
+      const dayEvents = this._events.filter(ev => dayKey(parseDueDate(ev.start.dateTime || ev.start.date)) === dk);
       const dayTasks = this._tasks.filter(task => {
         if (task.status === "completed") return false;
         const parsed = parseDueDate(task.due);
@@ -1858,7 +1859,7 @@ class CalendarTasksCard extends HTMLElement {
           // Tempo relativo "Manca X giorni" (per eventi è solo nel futuro, niente "scaduto")
           let rel = "";
           if (this._config.show_relative_time) {
-            const evDate = new Date(ev.start.dateTime || ev.start.date);
+            const evDate = parseDueDate(ev.start.dateTime || ev.start.date);
             const relText = formatRelativeTime(evDate, undefined, lang);
             if (relText) rel = `<div class="ctc-event-relative">${relText}</div>`;
           }


### PR DESCRIPTION
All-day calendar events render one day early in any timezone behind UTC.

`dayKey()` reads local date parts:

```js
function dayKey(date) { return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`; }
const dayEvents = this._events.filter(ev => dayKey(new Date(ev.start.dateTime || ev.start.date)) === dk);
```

but `new Date("2026-07-21")` is parsed as UTC midnight per spec, which in `America/New_York` is 20:00 on 20 July. So an all-day event dated today lands in yesterday's bucket, and today's slot fills up with tomorrow's events instead.

I hit this with `days: 1` on a wall dashboard. A daily all-day event showed up (tomorrow's instance) while a weekly one dated today did not, because there was no instance tomorrow to fill the slot. The card looked fine, it was just showing the wrong day.

Timed events are unaffected since `start.dateTime` carries an offset.

`parseDueDate()` already solves this for todos, so the fix is to route event starts through it as well. Three sites: the sort comparator in `_fetchCalendarEvents`, the `dayEvents` filter (the actual bug), and the relative time label.

Checked in `America/New_York`, `UTC`, `Europe/Rome` and `Pacific/Auckland`: after the change an all-day event dated today buckets to today in all four, and tomorrow's does not. Before the change the UTC and Auckland cases passed and New York failed, which lines up with it only affecting timezones behind UTC.